### PR TITLE
Support custom keyword handling

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,27 +1,27 @@
 (defproject metosin/jsonista "0.1.0-SNAPSHOT"
   :description "Clojure library for fast JSON encoding and decoding."
   :url "https://github.com/metosin/jsonista"
-  :license {:name         "Eclipse Public License"
-            :url          "http://www.eclipse.org/legal/epl-v10.html"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo
-            :comments     "same as Clojure"}
+            :comments "same as Clojure"}
   :source-paths ["src/clj"]
   :javac-options ["-Xlint:unchecked" "-target" "1.7" "-source" "1.7"]
   :java-source-paths ["src/java"]
   :plugins [[lein-codox "0.10.3"]
             [lein-virgil "0.1.7"]]
-  :codox {:src-uri     "http://github.com/metosin/jsonista/blob/master/{filepath}#L{line}"
+  :codox {:src-uri "http://github.com/metosin/jsonista/blob/master/{filepath}#L{line}"
           :output-path "doc"
-          :metadata    {:doc/format :markdown}}
+          :metadata {:doc/format :markdown}}
   :dependencies [[com.fasterxml.jackson.core/jackson-databind "2.9.2"]
                  [com.fasterxml.jackson.core/jackson-core "2.9.2"]]
-  :profiles {:dev  {:dependencies [[org.clojure/clojure "1.8.0"]
-                                   [criterium "0.4.4"]
-                                   [cheshire "5.8.0"]]}
-             :1.7  {:dependencies [[org.clojure/clojure "1.7.0"]]}
-             :1.9  {:dependencies [[org.clojure/clojure "1.9.0-alpha15"]]}
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
+                                  [criterium "0.4.4"]
+                                  [cheshire "5.8.0"]]}
+             :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
+             :1.9 {:dependencies [[org.clojure/clojure "1.9.0-RC2"]]}
              :perf {:jvm-opts ^:replace ["-server"
                                          "-Xmx4096m"
                                          "-Dclojure.compiler.direct-linking=true"]}}
-  :aliases {"all"  ["with-profile" "dev:dev,1.7:dev,1.9"]
+  :aliases {"all" ["with-profile" "default:dev:default:dev,1.7:default:dev,1.9"]
             "perf" ["with-profile" "default,dev,perf"]})

--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
   :javac-options ["-Xlint:unchecked" "-target" "1.7" "-source" "1.7"]
   :java-source-paths ["src/java"]
   :plugins [[lein-codox "0.10.3"]
-            [lein-virgil "0.1.7"]]
+            [lein-virgil "0.1.6"]]
   :codox {:src-uri "http://github.com/metosin/jsonista/blob/master/{filepath}#L{line}"
           :output-path "doc"
           :metadata {:doc/format :markdown}}

--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,7 @@
                                   [criterium "0.4.4"]
                                   [cheshire "5.8.0"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
-             :1.9 {:dependencies [[org.clojure/clojure "1.9.0-RC2"]]}
+             :1.9 {:dependencies [[org.clojure/clojure "1.9.0-RC1"]]}
              :perf {:jvm-opts ^:replace ["-server"
                                          "-Xmx4096m"
                                          "-Dclojure.compiler.direct-linking=true"]}}

--- a/src/clj/jsonista/core.clj
+++ b/src/clj/jsonista/core.clj
@@ -209,7 +209,7 @@
   ([object ^ObjectMapper mapper]
    (.writeValueAsString mapper object)))
 
-(defn ^bytes write-value-as-bytes
+(defn write-value-as-bytes
   "Encode a value as a JSON byte-array.
 
   To configure, pass in an ObjectMapper created with [[object-mapper]]."

--- a/src/clj/jsonista/core.clj
+++ b/src/clj/jsonista/core.clj
@@ -65,7 +65,7 @@
       module.SimpleModule
       SerializationFeature)
     (com.fasterxml.jackson.databind.module SimpleModule)
-    (java.io InputStream Writer File OutputStream DataOutput Reader)
+    (java.io InputStream Writer File OutputStream DataOutput Reader ByteArrayInputStream)
     (java.net URL)))
 
 (set! *warn-on-reflection* true)
@@ -200,7 +200,7 @@
   ([object ^ObjectMapper mapper]
    (-read-value object mapper)))
 
-(defn write-value-as-string
+(defn ^String write-value-as-string
   "Encode a value as a JSON string.
 
   To configure, pass in an ObjectMapper created with [[object-mapper]]."
@@ -209,7 +209,7 @@
   ([object ^ObjectMapper mapper]
    (.writeValueAsString mapper object)))
 
-(defn write-value-as-bytes
+(defn ^bytes write-value-as-bytes
   "Encode a value as a JSON byte-array.
 
   To configure, pass in an ObjectMapper created with [[object-mapper]]."

--- a/src/java/jsonista/jackson/DateSerializer.java
+++ b/src/java/jsonista/jackson/DateSerializer.java
@@ -24,6 +24,7 @@ public class DateSerializer extends StdSerializer<Date> {
 
   @Override
   public void serialize(Date value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+    // TODO: use something like jackson-datatype-jsr310?
     // SimpleDateFormat is not thread-safe, so we must synchronize it.
     synchronized (formatter) {
       gen.writeString(formatter.format(value));

--- a/src/java/jsonista/jackson/DateSerializer.java
+++ b/src/java/jsonista/jackson/DateSerializer.java
@@ -3,29 +3,30 @@ package jsonista.jackson;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
 import java.io.IOException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.SimpleTimeZone;
-import java.text.SimpleDateFormat;
 
 public class DateSerializer extends StdSerializer<Date> {
-    private final SimpleDateFormat formatter;
+  private final SimpleDateFormat formatter;
 
-    public DateSerializer(String dateFormat) {
-        super(DateSerializer.class, true);
-        formatter = new SimpleDateFormat(dateFormat);
-        formatter.setTimeZone(new SimpleTimeZone(0, "UTC"));
-    }
+  public DateSerializer(String dateFormat) {
+    super(DateSerializer.class, true);
+    formatter = new SimpleDateFormat(dateFormat);
+    formatter.setTimeZone(new SimpleTimeZone(0, "UTC"));
+  }
 
-    public DateSerializer() {
-        this("yyyy-MM-dd'T'HH:mm:ss'Z'");
-    }
+  public DateSerializer() {
+    this("yyyy-MM-dd'T'HH:mm:ss'Z'");
+  }
 
-    @Override
-    public void serialize(Date value, JsonGenerator gen, SerializerProvider provider) throws IOException {
-        // SimpleDateFormat is not thread-safe, so we must synchronize it.
-        synchronized(formatter) {
-            gen.writeString(formatter.format(value));
-        }
+  @Override
+  public void serialize(Date value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+    // SimpleDateFormat is not thread-safe, so we must synchronize it.
+    synchronized (formatter) {
+      gen.writeString(formatter.format(value));
     }
+  }
 }

--- a/src/java/jsonista/jackson/FunctionalKeyDeserializer.java
+++ b/src/java/jsonista/jackson/FunctionalKeyDeserializer.java
@@ -9,9 +9,8 @@ import java.io.IOException;
 public class FunctionalKeyDeserializer extends KeyDeserializer {
   private final IFn encoder;
 
-  public FunctionalKeyDeserializer(IFn encoderFunction) {
-    super();
-    encoder = encoderFunction;
+  public FunctionalKeyDeserializer(IFn encoder) {
+    this.encoder = encoder;
   }
 
   @Override

--- a/src/java/jsonista/jackson/FunctionalKeyDeserializer.java
+++ b/src/java/jsonista/jackson/FunctionalKeyDeserializer.java
@@ -1,0 +1,21 @@
+package jsonista.jackson;
+
+import clojure.lang.IFn;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.KeyDeserializer;
+
+import java.io.IOException;
+
+public class FunctionalKeyDeserializer extends KeyDeserializer {
+  private final IFn encoder;
+
+  public FunctionalKeyDeserializer(IFn encoderFunction) {
+    super();
+    encoder = encoderFunction;
+  }
+
+  @Override
+  public Object deserializeKey(String key, DeserializationContext ctxt) throws IOException {
+    return encoder.invoke(key);
+  }
+}

--- a/src/java/jsonista/jackson/FunctionalKeywordSerializer.java
+++ b/src/java/jsonista/jackson/FunctionalKeywordSerializer.java
@@ -1,0 +1,23 @@
+package jsonista.jackson;
+
+import clojure.lang.IFn;
+import clojure.lang.Keyword;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+
+public class FunctionalKeywordSerializer extends StdSerializer<Keyword> {
+  private final IFn encoder;
+
+  public FunctionalKeywordSerializer(IFn encoder) {
+    super(FunctionalKeywordSerializer.class, true);
+    this.encoder = encoder;
+  }
+
+  @Override
+  public void serialize(Keyword value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+    gen.writeFieldName(String.valueOf(encoder.invoke(value)));
+  }
+}

--- a/src/java/jsonista/jackson/FunctionalSerializer.java
+++ b/src/java/jsonista/jackson/FunctionalSerializer.java
@@ -8,15 +8,15 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import java.io.IOException;
 
 public class FunctionalSerializer<T> extends StdSerializer<T> {
-    private final IFn encoder;
+  private final IFn encoder;
 
-    public FunctionalSerializer(IFn encoderFunction) {
-        super(FunctionalSerializer.class, true);
-        encoder = encoderFunction;
-    }
+  public FunctionalSerializer(IFn encoderFunction) {
+    super(FunctionalSerializer.class, true);
+    encoder = encoderFunction;
+  }
 
-    @Override
-    public void serialize(T value, JsonGenerator gen, SerializerProvider provider) throws IOException {
-        encoder.invoke((Object) value, (Object) gen);
-    }
+  @Override
+  public void serialize(T value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+    encoder.invoke(value, gen);
+  }
 }

--- a/src/java/jsonista/jackson/FunctionalSerializer.java
+++ b/src/java/jsonista/jackson/FunctionalSerializer.java
@@ -10,9 +10,9 @@ import java.io.IOException;
 public class FunctionalSerializer<T> extends StdSerializer<T> {
   private final IFn encoder;
 
-  public FunctionalSerializer(IFn encoderFunction) {
+  public FunctionalSerializer(IFn encoder) {
     super(FunctionalSerializer.class, true);
-    encoder = encoderFunction;
+    this.encoder = encoder;
   }
 
   @Override

--- a/src/java/jsonista/jackson/KeywordKeyDeserializer.java
+++ b/src/java/jsonista/jackson/KeywordKeyDeserializer.java
@@ -8,12 +8,12 @@ import com.fasterxml.jackson.databind.KeyDeserializer;
 import java.io.IOException;
 
 public class KeywordKeyDeserializer extends KeyDeserializer {
-    public KeywordKeyDeserializer() {
-        super();
-    }
+  public KeywordKeyDeserializer() {
+    super();
+  }
 
-    @Override
-    public Object deserializeKey(String key, DeserializationContext ctxt) throws IOException, JsonProcessingException {
-        return Keyword.intern(key);
-    }
+  @Override
+  public Object deserializeKey(String key, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+    return Keyword.intern(key);
+  }
 }

--- a/src/java/jsonista/jackson/KeywordKeyDeserializer.java
+++ b/src/java/jsonista/jackson/KeywordKeyDeserializer.java
@@ -8,9 +8,6 @@ import com.fasterxml.jackson.databind.KeyDeserializer;
 import java.io.IOException;
 
 public class KeywordKeyDeserializer extends KeyDeserializer {
-  public KeywordKeyDeserializer() {
-    super();
-  }
 
   @Override
   public Object deserializeKey(String key, DeserializationContext ctxt) throws IOException, JsonProcessingException {

--- a/src/java/jsonista/jackson/KeywordSerializer.java
+++ b/src/java/jsonista/jackson/KeywordSerializer.java
@@ -8,20 +8,20 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import java.io.IOException;
 
 public class KeywordSerializer extends StdSerializer<Keyword> {
-    private final boolean writeFieldName;
+  private final boolean writeFieldName;
 
-    public KeywordSerializer(boolean writeFieldName) {
-        super(KeywordSerializer.class, true);
-        this.writeFieldName = writeFieldName;
-    }
+  public KeywordSerializer(boolean writeFieldName) {
+    super(KeywordSerializer.class, true);
+    this.writeFieldName = writeFieldName;
+  }
 
-    @Override
-    public void serialize(Keyword value, JsonGenerator gen, SerializerProvider provider) throws IOException {
-        String text = value.toString().substring(1);
-        if (writeFieldName) {
-            gen.writeFieldName(text);
-        } else {
-            gen.writeString(text);
-        }
+  @Override
+  public void serialize(Keyword value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+    String text = value.toString().substring(1);
+    if (writeFieldName) {
+      gen.writeFieldName(text);
+    } else {
+      gen.writeString(text);
     }
+  }
 }

--- a/src/java/jsonista/jackson/KeywordSerializer.java
+++ b/src/java/jsonista/jackson/KeywordSerializer.java
@@ -17,7 +17,7 @@ public class KeywordSerializer extends StdSerializer<Keyword> {
 
   @Override
   public void serialize(Keyword value, JsonGenerator gen, SerializerProvider provider) throws IOException {
-    String text = value.toString().substring(1);
+    String text = value.sym.toString();
     if (writeFieldName) {
       gen.writeFieldName(text);
     } else {

--- a/src/java/jsonista/jackson/PersistentHashMapDeserializer.java
+++ b/src/java/jsonista/jackson/PersistentHashMapDeserializer.java
@@ -14,26 +14,26 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import java.io.IOException;
 import java.util.Map;
 
-public class PersistentHashMapDeserializer extends StdDeserializer<Map<String,Object>> {
-    public PersistentHashMapDeserializer() {
-        super(Map.class);
+public class PersistentHashMapDeserializer extends StdDeserializer<Map<String, Object>> {
+  public PersistentHashMapDeserializer() {
+    super(Map.class);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public Map<String, Object> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+    ITransientMap t = PersistentHashMap.EMPTY.asTransient();
+    JavaType object = ctxt.constructType(Object.class);
+    KeyDeserializer keyDeser = ctxt.findKeyDeserializer(object, null);
+    JsonDeserializer<Object> valueDeser = ctxt.findNonContextualValueDeserializer(object);
+    while (p.nextToken() != JsonToken.END_OBJECT) {
+      Object key = keyDeser.deserializeKey(p.getCurrentName(), ctxt);
+      p.nextToken();
+      Object value = valueDeser.deserialize(p, ctxt);
+      t = t.assoc(key, value);
     }
 
-    @Override
-    @SuppressWarnings("unchecked")
-    public Map<String, Object> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
-        ITransientMap t = PersistentHashMap.EMPTY.asTransient();
-        JavaType object = ctxt.constructType(Object.class);
-        KeyDeserializer keyDeser = ctxt.findKeyDeserializer(object, null);
-        JsonDeserializer<Object> valueDeser = ctxt.findNonContextualValueDeserializer(object);
-        while (p.nextToken() != JsonToken.END_OBJECT) {
-            Object key = keyDeser.deserializeKey(p.getCurrentName(), ctxt);
-            p.nextToken();
-            Object value = valueDeser.deserialize(p, ctxt);
-            t = t.assoc(key, value);
-        }
-
-        // t.persistent() returns a PersistentHashMap, which is a Map.
-        return (Map<String,Object>)t.persistent();
-    }
+    // t.persistent() returns a PersistentHashMap, which is a Map.
+    return (Map<String, Object>) t.persistent();
+  }
 }

--- a/src/java/jsonista/jackson/PersistentHashMapDeserializer.java
+++ b/src/java/jsonista/jackson/PersistentHashMapDeserializer.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.util.Map;
 
 public class PersistentHashMapDeserializer extends StdDeserializer<Map<String, Object>> {
+
   public PersistentHashMapDeserializer() {
     super(Map.class);
   }

--- a/src/java/jsonista/jackson/PersistentVectorDeserializer.java
+++ b/src/java/jsonista/jackson/PersistentVectorDeserializer.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.util.List;
 
 public class PersistentVectorDeserializer extends StdDeserializer<List<Object>> {
+
   public PersistentVectorDeserializer() {
     super(List.class);
   }

--- a/src/java/jsonista/jackson/PersistentVectorDeserializer.java
+++ b/src/java/jsonista/jackson/PersistentVectorDeserializer.java
@@ -13,19 +13,19 @@ import java.io.IOException;
 import java.util.List;
 
 public class PersistentVectorDeserializer extends StdDeserializer<List<Object>> {
-    public PersistentVectorDeserializer() {
-        super(List.class);
-    }
+  public PersistentVectorDeserializer() {
+    super(List.class);
+  }
 
-    @Override
-    @SuppressWarnings("unchecked")
-    public List<Object> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
-        ITransientCollection t = PersistentVector.EMPTY.asTransient();
-        JsonDeserializer<Object> deser = ctxt.findNonContextualValueDeserializer(ctxt.constructType(Object.class));
-        while (p.nextValue() != JsonToken.END_ARRAY) {
-            t = t.conj(deser.deserialize(p, ctxt));
-        }
-        // t.persistent() returns a PersistentVector which is a list
-        return (List<Object>)t.persistent();
+  @Override
+  @SuppressWarnings("unchecked")
+  public List<Object> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+    ITransientCollection t = PersistentVector.EMPTY.asTransient();
+    JsonDeserializer<Object> deser = ctxt.findNonContextualValueDeserializer(ctxt.constructType(Object.class));
+    while (p.nextValue() != JsonToken.END_ARRAY) {
+      t = t.conj(deser.deserialize(p, ctxt));
     }
+    // t.persistent() returns a PersistentVector which is a list
+    return (List<Object>) t.persistent();
+  }
 }

--- a/src/java/jsonista/jackson/RatioSerializer.java
+++ b/src/java/jsonista/jackson/RatioSerializer.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import java.io.IOException;
 
 public class RatioSerializer extends StdSerializer<Ratio> {
+
   public RatioSerializer() {
     super(RatioSerializer.class, true);
   }

--- a/src/java/jsonista/jackson/RatioSerializer.java
+++ b/src/java/jsonista/jackson/RatioSerializer.java
@@ -8,12 +8,12 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import java.io.IOException;
 
 public class RatioSerializer extends StdSerializer<Ratio> {
-    public RatioSerializer() {
-        super(RatioSerializer.class, true);
-    }
+  public RatioSerializer() {
+    super(RatioSerializer.class, true);
+  }
 
-    @Override
-    public void serialize(Ratio value, JsonGenerator gen, SerializerProvider provider) throws IOException {
-        gen.writeNumber(value.doubleValue());
-    }
+  @Override
+  public void serialize(Ratio value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+    gen.writeNumber(value.doubleValue());
+  }
 }

--- a/src/java/jsonista/jackson/SymbolSerializer.java
+++ b/src/java/jsonista/jackson/SymbolSerializer.java
@@ -8,12 +8,12 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import java.io.IOException;
 
 public class SymbolSerializer extends StdSerializer<Symbol> {
-    public SymbolSerializer() {
-        super(SymbolSerializer.class, true);
-    }
+  public SymbolSerializer() {
+    super(SymbolSerializer.class, true);
+  }
 
-    @Override
-    public void serialize(Symbol value, JsonGenerator gen, SerializerProvider provider) throws IOException {
-        gen.writeString(value.toString());
-    }
+  @Override
+  public void serialize(Symbol value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+    gen.writeString(value.toString());
+  }
 }

--- a/src/java/jsonista/jackson/SymbolSerializer.java
+++ b/src/java/jsonista/jackson/SymbolSerializer.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import java.io.IOException;
 
 public class SymbolSerializer extends StdSerializer<Symbol> {
+
   public SymbolSerializer() {
     super(SymbolSerializer.class, true);
   }

--- a/test/jsonista/core_test.clj
+++ b/test/jsonista/core_test.clj
@@ -17,9 +17,9 @@
 (defn make-canonical [x] (-> x jsonista/read-value jsonista/write-value-as-string))
 (defn canonical= [x y] (= (make-canonical x) (make-canonical y)))
 
-(def +kw-mapper+ (jsonista/object-mapper {:key-fn true}))
-(def +upper-mapper+ (jsonista/object-mapper {:key-fn str/upper-case}))
-(def +string-mapper+ (jsonista/object-mapper {:key-fn false}))
+(def +kw-mapper+ (jsonista/object-mapper {:decode-key-fn true}))
+(def +upper-mapper+ (jsonista/object-mapper {:decode-key-fn str/upper-case}))
+(def +string-mapper+ (jsonista/object-mapper {:decode-key-fn false}))
 
 (deftest simple-roundrobin-test
   (is (stays-same? {"hello" "world"}))
@@ -32,11 +32,16 @@
 
 (deftest options-tests
   (let [data {:hello "world"}]
-    (testing ":key-fn"
+    (testing ":decode-key-fn"
       (is (= {"hello" "world"} (-> data jsonista/write-value-as-string jsonista/read-value)))
       (is (= {:hello "world"} (-> data (jsonista/write-value-as-string) (jsonista/read-value +kw-mapper+))))
       (is (= {"hello" "world"} (-> data (jsonista/write-value-as-string) (jsonista/read-value +string-mapper+))))
       (is (= {"HELLO" "world"} (-> data (jsonista/write-value-as-string) (jsonista/read-value +upper-mapper+)))))
+    (testing ":encode-key-fn"
+      (let [data {:hello "world"}]
+        (is (= "{\"hello\":\"world\"}" (jsonista/write-value-as-string data (jsonista/object-mapper {:encode-key-fn true}))))
+        (is (= "{\":hello\":\"world\"}" (jsonista/write-value-as-string data (jsonista/object-mapper {:encode-key-fn false}))))
+        (is (= "{\"HELLO\":\"world\"}" (jsonista/write-value-as-string data (jsonista/object-mapper {:encode-key-fn (comp str/upper-case name)}))))))
     (testing ":pretty"
       (is (= "{\n  \"hello\" : \"world\"\n}" (jsonista/write-value-as-string data (jsonista/object-mapper {:pretty true})))))
     (testing ":escape-non-ascii"
@@ -116,7 +121,7 @@
 (deftest custom-encoders
   (let [data {:like (StringLike. "boss")}
         expected {:like "boss"}
-        mapper (jsonista/object-mapper {:key-fn true
+        mapper (jsonista/object-mapper {:decode-key-fn true
                                         :encoders {StringLike serialize-stringlike}})]
 
     (testing "cheshire"
@@ -129,7 +134,7 @@
       (is (= expected (-> data (jsonista/write-value-as-string mapper) (jsonista/read-value mapper)))))
 
     (testing "using JsonSerializer instances"
-      (let [mapper (jsonista/object-mapper {:key-fn true
+      (let [mapper (jsonista/object-mapper {:decode-key-fn true
                                             :encoders {StringLike (FunctionalSerializer. serialize-stringlike)}})]
         (is (canonical= (cheshire/generate-string data) (jsonista/write-value-as-string data mapper)))
         (is (= expected (-> data (jsonista/write-value-as-string mapper) (jsonista/read-value mapper)))))))

--- a/test/jsonista/core_test.clj
+++ b/test/jsonista/core_test.clj
@@ -12,6 +12,8 @@
            (clojure.lang Keyword ExceptionInfo)
            (com.fasterxml.jackson.databind JsonSerializer)))
 
+(set! *warn-on-reflection* true)
+
 (defn stays-same? [x] (= x (-> x jsonista/write-value-as-string jsonista/read-value)))
 
 (defn make-canonical [x] (-> x jsonista/read-value jsonista/write-value-as-string))
@@ -145,7 +147,7 @@
           #"Can't register encoder 123 for type class clojure.lang.Keyword"
           (jsonista/object-mapper {:encoders {Keyword 123}})))))
 
-(defn- str->input-stream [x] (ByteArrayInputStream. (.getBytes x "UTF-8")))
+(defn- str->input-stream [^String x] (ByteArrayInputStream. (.getBytes x "UTF-8")))
 
 (defn tmp-file ^File [] (File/createTempFile "temp" ".json"))
 

--- a/test/jsonista/json_perf_test.clj
+++ b/test/jsonista/json_perf_test.clj
@@ -30,41 +30,35 @@
 
 (defn encode-perf []
 
-  ;; 1005ns
+  ;; 1220ns
   (title "encode: cheshire")
-  (let [encode (fn [] (cheshire/generate-string {"hello" "world"}))]
-    (assert (= +json+ (encode)))
-    (cc/quick-bench (encode)))
+  (assert (= +json+ (cheshire/generate-string {"hello" "world"})))
+  (cc/quick-bench (cheshire/generate-string {"hello" "world"}))
 
-  ;; 249ns
-  ;; 201ns
+  ;; 200ns
   (title "encode: jsonista")
-  (let [encode (fn [] (json/write-value-as-string {"hello" "world"}))]
-    (assert (= +json+ (encode)))
-    (cc/quick-bench (encode)))
+  (assert (= +json+ (json/write-value-as-string {"hello" "world"})))
+  (cc/quick-bench (json/write-value-as-string {"hello" "world"}))
 
-  ;; 82ns
+  ;; 110ns
   (title "encode: str")
-  (let [encode (fn [] (str "{\"hello\":\"" "world" "\"}"))]
-    (assert (= +json+ (encode)))
-    (cc/quick-bench (encode))))
+  (let [encode (fn [key value] (str "{\"" key "\":\"" value "\"}"))]
+    (assert (= +json+ (encode "hello" "world")))
+    (cc/quick-bench (encode "hello" "world"))))
 
 (defn decode-perf []
 
-  ;; 896ns
+  ;; 920ns
   (title "decode: cheshire")
-  (let [decode (fn [] (cheshire/parse-string-strict +json+))]
-    (assert (= +data+ (decode)))
-    (cc/quick-bench (decode)))
+  (assert (= +data+ (cheshire/parse-string-strict +json+)))
+  (cc/quick-bench (cheshire/parse-string-strict +json+))
 
-  ;; 416ns
-  ;; 378ns
+  ;; 412ns
   (title "decode: jsonista")
-  (let [decode (fn [] (json/read-value +json+))]
-    (assert (= +data+ (decode)))
-    (cc/quick-bench (decode)))
+  (assert (= +data+ (json/read-value +json+)))
+  (cc/quick-bench (json/read-value +json+))
 
-  ;; 246ns
+  ;; 260ns
   (title "decode: jackson")
   (let [mapper (ObjectMapper.)
         decode (fn [] (.readValue mapper +json+ Map))]
@@ -79,32 +73,26 @@
                 "dev-resources/json100k.json"]
           :let [data (cheshire/parse-string (slurp file))
                 json (cheshire/generate-string data)]]
-    (let [encode-cheshire (fn [] (cheshire/generate-string data))
-          encode-jsonista (fn [] (json/write-value-as-string data))]
 
-      (title file)
-      (println data)
+    (title file)
 
-      ;  1.1µs (10b)
-      ;  2.6µs (100b)
-      ;  8.7µs (1k)
-      ;   92µs (10k)
-      ;  915µs (100k)
-      (title "encode: cheshire")
-      (assert (= json (encode-cheshire)))
-      (cc/quick-bench (encode-cheshire))
+    ;  1.2µs (10b)
+    ;  3.0µs (100b)
+    ; 12.6µs (1k)
+    ;  134µs (10k)
+    ; 1290µs (100k)
+    (title "encode: cheshire")
+    (assert (= json (cheshire/generate-string data)))
+    (cc/quick-bench (cheshire/generate-string data))
 
-      ;  0.2µs (10b)  - +450%
-      ;  0.6µs (100b) - +330%
-      ;  3.2µs (1k)   - +170%
-      ;   36µs (10k)  - +150%
-      ;  360µs (100k) - +150%
-      (title "encode: jsonista")
-      (assert (= json (encode-jsonista)))
-      (cc/quick-bench (encode-jsonista)))))
-
-(comment
-  (encode-perf-different-sizes))
+    ; 0.23µs (10b)
+    ; 0.58µs (100b)
+    ;  3.3µs (1k)
+    ;   36µs (10k)
+    ;  380µs (100k)
+    (title "encode: jsonista")
+    (assert (= json (json/write-value-as-string data)))
+    (cc/quick-bench (json/write-value-as-string data))))
 
 (defn decode-perf-different-sizes []
   (doseq [file ["dev-resources/json10b.json"
@@ -114,29 +102,26 @@
                 "dev-resources/json100k.json"]
           :let [data (cheshire/parse-string (slurp file))
                 json (cheshire/generate-string data)]]
-    (let [decode-cheshire (fn [] (cheshire/parse-string json))
-          decode-jsonista (fn [] (json/read-value json))]
 
-      (title file)
+    (title file)
 
-      ;  1.0µs (10b)
-      ;  2.0µs (100b)
-      ;   10µs (1k)
-      ;  110µs (10k)
-      ; 1000µs (100k)
-      (title "decode: cheshire")
-      (assert (= data (decode-cheshire)))
-      (cc/quick-bench (decode-cheshire))
+    ;  1.0µs (10b)
+    ;  2.2µs (100b)
+    ;  9.3µs (1k)
+    ;  106µs (10k)
+    ; 1010µs (100k)
+    (title "decode: cheshire")
+    (assert (= data (cheshire/parse-string json)))
+    (cc/quick-bench (cheshire/parse-string json))
 
-      ;  0.4µs (10b)  - +150%
-      ;  1.5µs (100b) -  +30%
-      ;  7.6µs (1k)   -  +30%
-      ;   84µs (10k)  -  +30%
-      ;  770µs (100k) -  +30%
-      (title "decode: jsonista")
-      (assert (= data (decode-jsonista)))
-      (cc/quick-bench (decode-jsonista)))))
-
+    ; 0.40µs (10b)
+    ;  1.6µs (100b)
+    ;  7.8µs (1k)
+    ;   84µs (10k)
+    ;  806µs (100k)
+    (title "decode: jsonista")
+    (assert (= data (json/read-value json)))
+    (cc/quick-bench (json/read-value json))))
 
 (comment
   (encode-perf)

--- a/test/jsonista/test_utils.clj
+++ b/test/jsonista/test_utils.clj
@@ -1,18 +1,4 @@
-(ns jsonista.test-utils
-  (:import [java.io ByteArrayInputStream]))
-
-(set! *warn-on-reflection* true)
-
-(defn request-stream [request]
-  (let [b (.getBytes ^String (:body request))]
-    (fn []
-      (assoc request :body (ByteArrayInputStream. b)))))
-
-(defn context-stream [request]
-  (let [b (.getBytes ^String (:body request))
-        ctx {:request request}]
-    (fn []
-      (assoc-in ctx [:request :body] (ByteArrayInputStream. b)))))
+(ns jsonista.test-utils)
 
 (defn title [s]
   (println


### PR DESCRIPTION
remove `:keywordize?` in favour of:

```clj
  | `:encode-key-fn`    | true to coerce keyword keys to strings, false to leave them as keywords, or a function to provide custom coercion (default: true) |
  | `:decode-key-fn`    | true to coerce keys to keywords, false to leave them as strings, or a function to provide custom coercion (default: false) |"
```

here's the relevant tests:

```clj
(def +kw-mapper+ (jsonista/object-mapper {:decode-key-fn true}))
(def +upper-mapper+ (jsonista/object-mapper {:decode-key-fn str/upper-case}))
(def +string-mapper+ (jsonista/object-mapper {:decode-key-fn false}))
(deftest options-tests
  (let [data {:hello "world"}]
    (testing ":decode-key-fn"
      (is (= {"hello" "world"} (-> data jsonista/write-value-as-string jsonista/read-value)))
      (is (= {:hello "world"} (-> data (jsonista/write-value-as-string) (jsonista/read-value +kw-mapper+))))
      (is (= {"hello" "world"} (-> data (jsonista/write-value-as-string) (jsonista/read-value +string-mapper+))))
      (is (= {"HELLO" "world"} (-> data (jsonista/write-value-as-string) (jsonista/read-value +upper-mapper+)))))
    (testing ":encode-key-fn"
      (let [data {:hello "world"}]
        (is (= "{\"hello\":\"world\"}" (jsonista/write-value-as-string data (jsonista/object-mapper {:encode-key-fn true}))))
        (is (= "{\":hello\":\"world\"}" (jsonista/write-value-as-string data (jsonista/object-mapper {:encode-key-fn false}))))
        (is (= "{\"HELLO\":\"world\"}" (jsonista/write-value-as-string data (jsonista/object-mapper {:encode-key-fn (comp str/upper-case name)}))))))
    (testing ":pretty"
      (is (= "{\n  \"hello\" : \"world\"\n}" (jsonista/write-value-as-string data (jsonista/object-mapper {:pretty true})))))
    (testing ":escape-non-ascii"
      (is (= "{\"imperial-money\":\"\\u00A3\"}" (jsonista/write-value-as-string {:imperial-money "£"} (jsonista/object-mapper {:escape-non-ascii true})))))
    (testing ":date-format"
      (is (= "{\"mmddyyyy\":\"00-01-70\"}" (jsonista/write-value-as-string {:mmddyyyy (Date. 0)} (jsonista/object-mapper {:date-format "mm-dd-yy"})))))))
```

With defaults, use the same code as before, so no change in perf. Except one can transform keys in single sweep making things much faster.
