### PR TITLE
Add tagged value module

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,26 @@ Adding support for [joda-time](http://www.joda.org/joda-time) Classes, used by [
 (j/write-value-as-string (LocalDate. 0) mapper)
 ; "\"1970-01-01\""
 ```
+
+Adding support for lossless encoding of keywords using tagged values. This
+includes both reading and writing support.
+
+```clj
+(require '[jsonista.tagged-value :as tagged-value])
+
+(def mapper
+  (j/object-mapper
+    {:encode-key-fn true
+     :decode-key-fn true
+     :modules [(tagged-value/module {:keyword-tag "!kw"})]}))
+
+(j/write-value-as-string {:system/status :status/good} mapper)
+; "{\"system/status\":[\"!kw\",\"status/good\"]}"
+
+(-> (j/write-value-as-string {:system/status :status/good} mapper)
+    (j/read-value mapper))
+; {:system/status :status/good}
+
 ## Performance
 
 * All standard encoders and decoders are written in Java

--- a/src/clj/jsonista/tagged_value.clj
+++ b/src/clj/jsonista/tagged_value.clj
@@ -1,0 +1,28 @@
+(ns jsonista.tagged-value
+  (:import [jsonista.jackson FunctionalSerializer TaggedValueOrPersistentVectorDeserializer]
+           [com.fasterxml.jackson.core JsonGenerator]
+           [com.fasterxml.jackson.databind.module SimpleModule]))
+
+(defn- encode-keyword [^String tag ^clojure.lang.Keyword kw ^JsonGenerator gen]
+  (.writeStartArray gen)
+  (.writeString gen tag)
+  (.writeString gen (.substring (.toString kw) 1))
+  (.writeEndArray gen))
+
+(defn module
+  "Create a Jackson Databind module to support losslessly encoded tagged values.
+
+   This provides both encoders and decoders and is a means of using jsonista to replace something
+   like transit, while still maintaining support for more EDN types. Types are encoded using a JSON
+   list and a customizable tag. For example, `:foo/bar` would serialize to `[\"!kw\", \"foo/bar\"]`
+   by default, where the first string in the JSON list is a tag for what follows.
+
+   For now, supported additional types are:
+
+   * Keyword"
+  ^SimpleModule
+  [{:keys [keyword-tag]
+    :or {keyword-tag "!kw"}}]
+  (doto (SimpleModule. "TaggedValue")
+    (.addDeserializer java.util.List (TaggedValueOrPersistentVectorDeserializer. ^String keyword-tag))
+    (.addSerializer clojure.lang.Keyword (FunctionalSerializer. #(encode-keyword keyword-tag %1 %2)))))

--- a/src/java/jsonista/jackson/TaggedValueOrPersistentVectorDeserializer.java
+++ b/src/java/jsonista/jackson/TaggedValueOrPersistentVectorDeserializer.java
@@ -1,0 +1,50 @@
+package jsonista.jackson;
+
+import clojure.lang.Keyword;
+import clojure.lang.ITransientCollection;
+import clojure.lang.PersistentVector;
+import clojure.lang.Indexed;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+import java.util.List;
+
+public class TaggedValueOrPersistentVectorDeserializer extends StdDeserializer<Object> {
+  private final String tag;
+
+  public TaggedValueOrPersistentVectorDeserializer(String tag) {
+    super(List.class);
+    this.tag = tag;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+    JsonDeserializer<Object> deser = ctxt.findNonContextualValueDeserializer(ctxt.constructType(Object.class));
+    ITransientCollection t = PersistentVector.EMPTY.asTransient();
+    if (p.nextValue() != JsonToken.END_ARRAY) {
+      t = t.conj(deser.deserialize(p, ctxt));
+      Object maybeTag = ((Indexed) t).nth(0);
+      if (maybeTag instanceof String && tag.equals(maybeTag)) {
+        /* Jump to keyword. */
+        p.nextValue();
+        Keyword keyword = Keyword.intern((String) deser.deserialize(p, ctxt));
+        /* Jump to end of list. */
+        p.nextValue();
+        return keyword;
+      }
+    } else {
+      return (List<Object>) t.persistent();
+    }
+
+    while (p.nextValue() != JsonToken.END_ARRAY) {
+      t = t.conj(deser.deserialize(p, ctxt));
+    }
+    return (List<Object>) t.persistent();
+  }
+}

--- a/test/jsonista/tagged_value_test.clj
+++ b/test/jsonista/tagged_value_test.clj
@@ -1,0 +1,30 @@
+(ns jsonista.tagged-value-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [jsonista.core :as j]
+            [jsonista.tagged-value :as tagged-value]))
+
+(deftest tagged-value-test
+  (let [mapper (j/object-mapper {:modules [(tagged-value/module {:keyword-tag "!kw"})]})
+        data {:system/status :status/good
+              :system/statuses [:status/good :status/bad]}]
+    (testing "encoding"
+      (testing "with defaults"
+        (is (= "{\"system/status\":\"status/good\",\"system/statuses\":[\"status/good\",\"status/bad\"]}"
+               (j/write-value-as-string data))))
+      (testing "with installed module"
+        (is (= "{\"system/status\":[\"!kw\",\"status/good\"],\"system/statuses\":[[\"!kw\",\"status/good\"],[\"!kw\",\"status/bad\"]]}"
+               (j/write-value-as-string data mapper)))))
+
+    (testing "decoding"
+      (testing "with defaults"
+        (is (= {"system/status" "status/good"
+                "system/statuses" ["status/good" "status/bad"]}
+               (j/read-value (j/write-value-as-string data)))))
+      (testing "with installed module"
+        (is (= {"system/status" :status/good
+                "system/statuses" [:status/good :status/bad]}
+               (j/read-value (j/write-value-as-string data mapper) mapper)))))
+
+    (testing "empty list"
+      (let [data {:foo []}]
+        (is (= {"foo" []} (j/read-value (j/write-value-as-string {:foo []} mapper) mapper)))))))


### PR DESCRIPTION
This aims to open the doors for jsonista to become a viable alternative
for people currently using EDN with transit by providing a way to encode
EDN types using a tagged JSON list. Currently, only keywords are
supported.

Regarding `TaggedValueOrPersistentVectorDeserializer`, it's worth noting
that it doesn't just peek for a tag and then fall back on the default
`PersistentVectorDeserializer`, since peeking seemed to require a call
to `nextValue()` and I found no way to backtack. So it seems I need to
try building the transient and then just special-case the zeroth element
to check for the tag.

Right now, it doesn't do anything special with mapping tags to different
types in the Java code, since there's only one and I figure that change
can be made when it's needed. The Clojure API, however, remains more
general, since the tag needs to come in as a key.  This will make adding
new keys to the API trivial, if more types are supported in the future.

This closes #35.