### PR TITLE
Implement custom deserializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ pom.xml*
 .#*
 /doc/
 \#*\#
+.idea
+*.iml

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject metosin/jsonista "0.2.7"
+(defproject alpha-prosoft/jsonista "0.2.8"
   :description "Clojure library for fast JSON encoding and decoding."
-  :url "https://github.com/metosin/jsonista"
+  :url "https://github.com/alpha-prosoft/jsonista"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v20.html"}
   :source-paths ["src/clj"]
@@ -9,7 +9,7 @@
   :plugins [[lein-codox "0.10.7"]
             [lein-jmh "0.3.0"]]
   :deploy-repositories [["releases" :clojars]]
-  :codox {:source-uri "http://github.com/metosin/jsonista/blob/master/{filepath}#L{line}"
+  :codox {:source-uri "http://github.com/alpha-prosoft/jsonista/blob/master/{filepath}#L{line}"
           :output-path "doc"
           :metadata {:doc/format :markdown}}
   :dependencies [[com.fasterxml.jackson.core/jackson-core "2.11.2"]

--- a/src/clj/jsonista/core.clj
+++ b/src/clj/jsonista/core.clj
@@ -54,6 +54,8 @@
       FunctionalSerializer
       KeywordSerializer
       KeywordKeyDeserializer
+      FunctionalPersistentHashMapDeserializer
+      FunctionalPersistentVectorDeserializer
       PersistentHashMapDeserializer
       PersistentVectorDeserializer
       SymbolSerializer
@@ -73,11 +75,15 @@
   "Create a Jackson Databind module to support Clojure datastructures.
 
   See [[object-mapper]] docstring for the documentation of the options."
-  [{:keys [encode-key-fn decode-key-fn encoders date-format]
-    :or {encode-key-fn true, decode-key-fn false}}]
+  [{:keys [encode-key-fn decode-key-fn encoders date-format decode-fn]
+    :or   {encode-key-fn true, decode-key-fn false}}]
   (doto (SimpleModule. "Clojure")
-    (.addDeserializer java.util.List (PersistentVectorDeserializer.))
-    (.addDeserializer java.util.Map (PersistentHashMapDeserializer.))
+    (.addDeserializer java.util.List (if (fn? decode-fn)
+                                       (FunctionalPersistentVectorDeserializer. decode-fn)
+                                       (PersistentVectorDeserializer.)))
+    (.addDeserializer java.util.Map (if (fn? decode-fn)
+                                      (FunctionalPersistentHashMapDeserializer. decode-fn)
+                                      (PersistentHashMapDeserializer.)))
     (.addSerializer clojure.lang.Keyword (KeywordSerializer. false))
     (.addSerializer clojure.lang.Ratio (RatioSerializer.))
     (.addSerializer clojure.lang.Symbol (SymbolSerializer.))

--- a/src/java/jsonista/jackson/FunctionalPersistentHashMapDeserializer.java
+++ b/src/java/jsonista/jackson/FunctionalPersistentHashMapDeserializer.java
@@ -1,0 +1,44 @@
+package jsonista.jackson;
+
+import clojure.lang.IFn;
+import clojure.lang.ITransientMap;
+import clojure.lang.PersistentHashMap;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.KeyDeserializer;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class FunctionalPersistentHashMapDeserializer extends StdDeserializer<Map<String, Object>> {
+
+  private final IFn decoder;
+
+  public FunctionalPersistentHashMapDeserializer(IFn decoder) {
+    super(Map.class);
+    this.decoder = decoder;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public Map<String, Object> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+    ITransientMap t = PersistentHashMap.EMPTY.asTransient();
+    JavaType object = ctxt.constructType(Object.class);
+    KeyDeserializer keyDeser = ctxt.findKeyDeserializer(object, null);
+    JsonDeserializer<Object> valueDeser = ctxt.findNonContextualValueDeserializer(object);
+    while (p.nextToken() != JsonToken.END_OBJECT) {
+      Object key = keyDeser.deserializeKey(p.getCurrentName(), ctxt);
+      p.nextToken();
+      Object value = valueDeser.deserialize(p, ctxt);
+      t = t.assoc(key, decoder.invoke(value));
+    }
+
+    // t.persistent() returns a PersistentHashMap, which is a Map.
+    return (Map<String, Object>) t.persistent();
+  }
+}

--- a/src/java/jsonista/jackson/FunctionalPersistentVectorDeserializer.java
+++ b/src/java/jsonista/jackson/FunctionalPersistentVectorDeserializer.java
@@ -1,0 +1,37 @@
+package jsonista.jackson;
+
+import clojure.lang.IFn;
+import clojure.lang.ITransientCollection;
+import clojure.lang.PersistentVector;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+import java.util.List;
+
+public class FunctionalPersistentVectorDeserializer extends StdDeserializer<List<Object>> {
+
+  private final IFn decoder;
+
+  public FunctionalPersistentVectorDeserializer(IFn decoder) {
+    super(List.class);
+    this.decoder = decoder;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public List<Object> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+    ITransientCollection t = PersistentVector.EMPTY.asTransient();
+    JsonDeserializer<Object> deser = ctxt.findNonContextualValueDeserializer(ctxt.constructType(Object.class));
+    while (p.nextValue() != JsonToken.END_ARRAY) {
+      Object value = deser.deserialize(p, ctxt);
+      t = t.conj(decoder.invoke(value));
+    }
+    // t.persistent() returns a PersistentVector which is a list
+    return (List<Object>) t.persistent();
+  }
+}


### PR DESCRIPTION
When we are using json there is lots of information
is passed out of channel. This is in java covered by types.

Usualy in clojure this is not a problem. From my experience
there are 2 types that caued issues. That where keyward
and uuis. Because they are not objects they cannot be
deserialized to map or vector like usuall java objects are.
They in that way behave as if they where primitives.

Problem comes when there is nested data structure containing
some of those. When we serialize such structure in Json
we loos information about this 2 types.

To support such case, a function that can customize
decoding process is proposed.

This function will not affect any existing path in code.

Function accepts java Object type and outputs Object type.

Sample implementeation provided in tests