### PR TITLE
Remove reflection on ObjectMapper

### DIFF
--- a/src/clj/jsonista/core.clj
+++ b/src/clj/jsonista/core.clj
@@ -135,7 +135,7 @@
                        maybe-mapper maybe-mapper
                        factory (ObjectMapper. ^JsonFactory factory)
                        :else (ObjectMapper.))
-         mapper (doto base-mapper
+         mapper (doto ^ObjectMapper base-mapper
                   (.registerModule (JavaTimeModule.))
                   (.registerModule (clojure-module options))
                   (cond->


### PR DESCRIPTION
Before:
```sh
$ lein do clean, check
Compiling 11 source files to /Users/dpassen/apps/jsonista/target/classes
Compiling namespace jsonista.core
Reflection warning, jsonista/core.clj:139:19 - call to method registerModule can't be resolved (target class is unknown).
Reflection warning, jsonista/core.clj:140:19 - call to method registerModule can't be resolved (target class is unknown).
Reflection warning, jsonista/core.clj:142:39 - call to method enable can't be resolved (target class is unknown).
Reflection warning, jsonista/core.clj:143:44 - call to method enable can't be resolved (target class is unknown).
Reflection warning, jsonista/core.clj:144:71 - reference to field getFactory can't be resolved.
Reflection warning, jsonista/core.clj:144:71 - call to method enable can't be resolved (target class is unknown).
Reflection warning, jsonista/core.clj:146:8 - call to method registerModule can't be resolved (target class is unknown).
Reflection warning, jsonista/core.clj:146:8 - call to method registerModule can't be resolved (target class is unknown).
Reflection warning, jsonista/core.clj:147:6 - call to method disable can't be resolved (target class is unknown).
Compiling namespace jsonista.tagged
```

After:
```sh
$ lein do clean, check
Compiling 11 source files to /Users/dpassen/apps/jsonista/target/classes
Compiling namespace jsonista.core
Compiling namespace jsonista.tagged
```