### PR TITLE
Allow keys with no values to be removed during encoding

### DIFF
--- a/src/clj/jsonista/core.clj
+++ b/src/clj/jsonista/core.clj
@@ -61,6 +61,7 @@
       SymbolSerializer
       RatioSerializer FunctionalKeywordSerializer)
     (com.fasterxml.jackson.core JsonGenerator$Feature JsonFactory)
+    (com.fasterxml.jackson.annotation JsonInclude$Include)
     (com.fasterxml.jackson.databind
       JsonSerializer ObjectMapper module.SimpleModule
       SerializationFeature DeserializationFeature Module)
@@ -123,6 +124,7 @@
   | ------------------- | ------------------------------------------------- |
   | `:pretty`           | set to true use Jacksons pretty-printing defaults |
   | `:escape-non-ascii` | set to true to escape non ascii characters        |
+  | `:strip-nils`       | remove any keys that have nil values              |
   | `:date-format`      | string for custom date formatting. default: `yyyy-MM-dd'T'HH:mm:ss'Z'`  |
   | `:encode-key-fn`    | true to coerce keyword keys to strings, false to leave them as keywords, or a function to provide custom coercion (default: true) |
   | `:encoders`         | a map of custom encoders where keys should be types and values should be encoder functions |
@@ -149,6 +151,7 @@
                   (cond->
                     (:pretty options) (.enable SerializationFeature/INDENT_OUTPUT)
                     (:bigdecimals options) (.enable DeserializationFeature/USE_BIG_DECIMAL_FOR_FLOATS)
+                    (:strip-nils options) (.setSerializationInclusion JsonInclude$Include/NON_EMPTY)
                     (:escape-non-ascii options) (doto (-> .getFactory (.enable JsonGenerator$Feature/ESCAPE_NON_ASCII)))))]
      (doseq [module (:modules options)]
        (.registerModule mapper module))

--- a/test/jsonista/core_test.clj
+++ b/test/jsonista/core_test.clj
@@ -54,6 +54,9 @@
         (is (= "{\"HELLO\":\"world\"}" (j/write-value-as-string data (j/object-mapper {:encode-key-fn (comp str/upper-case name)}))))))
     (testing ":pretty"
       (is (= "{\n  \"hello\" : \"world\"\n}" (j/write-value-as-string data (j/object-mapper {:pretty true})))))
+    (testing ":strip-nils"
+      (let [data-with-nils {:hello "world" :goodbye nil}]
+        (is (= "{\"hello\":\"world\"}" (j/write-value-as-string data-with-nils (j/object-mapper {:strip-nils true}))))))
     (testing ":escape-non-ascii"
       (is (= "{\"imperial-money\":\"\\u00A3\"}" (j/write-value-as-string {:imperial-money "£"} (j/object-mapper {:escape-non-ascii true})))))
     (testing ":date-format"
@@ -267,4 +270,3 @@
       (j/write-value (FileWriter. file) original)
       (is (= expected (slurp file)))
       (.delete file))))
-


### PR DESCRIPTION
A common scenario when serialising out to JSON, is the ability to remove any keys that have nil values, thus resulting in a more compact object being sent over the wire.

This small change introduces a new encoding option that, if set, will do precisely that.

Fixes #66

-=david=-