### PR TITLE
Support String Deserialization for explicit null values

### DIFF
--- a/src/clj/jsonista/core.clj
+++ b/src/clj/jsonista/core.clj
@@ -59,6 +59,7 @@
     PersistentHashMapDeserializer
     PersistentVectorDeserializer
     SymbolSerializer
+    StringDeserializer
     RatioSerializer FunctionalKeywordSerializer)
    (com.fasterxml.jackson.core JsonGenerator$Feature JsonFactory)
    (com.fasterxml.jackson.annotation JsonInclude$Include)
@@ -81,6 +82,7 @@
   (doto (SimpleModule. "Clojure")
     (.addDeserializer List (PersistentVectorDeserializer.))
     (.addDeserializer Map (PersistentHashMapDeserializer.))
+    (.addDeserializer String (StringDeserializer.))
     (.addSerializer Keyword (KeywordSerializer. false))
     (.addSerializer Ratio (RatioSerializer.))
     (.addSerializer Symbol (SymbolSerializer.))

--- a/src/java/jsonista/jackson/StringDeserializer.java
+++ b/src/java/jsonista/jackson/StringDeserializer.java
@@ -1,0 +1,32 @@
+package jsonista.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+
+public class StringDeserializer extends StdDeserializer<String> {
+    /*
+     * StringDeserializer focuses on _deserializing_ String values for those that have `null` specified to `clojure.core/nil`
+     */
+    public static final String NULL = "null";
+
+    public StringDeserializer() {
+        super(String.class);
+    }
+
+    @Override
+    public String deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        JsonToken t = p.getCurrentToken();
+        String textValue = p.getText();
+        if (t == JsonToken.VALUE_NULL) {
+            return null;
+        }
+        else if (t == JsonToken.VALUE_STRING && textValue.equals(NULL)) {
+            return null;
+        }
+        return textValue;
+    };
+}

--- a/test/jsonista/core_test.clj
+++ b/test/jsonista/core_test.clj
@@ -240,6 +240,12 @@
     (testing "String"
       (is (= original (j/read-value input-string))))
 
+    (testing "String_Specfied_Null"
+      (let [json-string-with-null-value "{\"value\": \"null\"}"
+            clj-json-map                (j/read-value json-string-with-null-value)]
+        (is (= nil (get clj-json-map "value")))
+        (is (= {"value" nil} clj-json-map))))
+
     (testing "InputStream"
       (is (= original (j/read-value (str->input-stream input-string)))))
 


### PR DESCRIPTION
 ## Context
* With `jsonista` when we try to convert `json-string` to `map` via `jsonista.core/read-value`, the **deserialization for works fine all cases** _EXCEPT_ for `values` with `null` string. i.e.,
```clojure
(def json-string "{\"user-name\" \"null\"}")
=> dev/json-string

(def parsed-json (jsonista.core/read-value json-string))
=> dev/parsed-json

;; Instead of {"user-name" nil}, which we desire We get {"user-name" "null"}
;; This is because, the `Object` _deserialization_ for `String` doesn't handle this _explicit_ scenario. Thus this fix

;; After the current fix, we will get the output as
{"user-name" nil}
```

 ## Fixes done
* Created a `StringDeserializer` that handles the _explicit_ `null` scneario
* Added _deserializer_ to `SimpleModule` for `String`
* Added some test cases for verify the same

 ## Unit testing
* All test cases passes :100:
<img width="802" alt="Screenshot 2023-10-28 at 2 32 26 AM" src="https://github.com/metosin/jsonista/assets/42887658/56c9a7c8-1d60-4170-a416-415d8ac4db9c">
