### PR TITLE
Update strip-nils to only strip nils, not empty strings, maps, etc

### DIFF
--- a/src/clj/jsonista/core.clj
+++ b/src/clj/jsonista/core.clj
@@ -154,7 +154,7 @@
                    (:order-by-keys options) (.configure SerializationFeature/ORDER_MAP_ENTRIES_BY_KEYS true)
                    (:pretty options) (.enable SerializationFeature/INDENT_OUTPUT)
                    (:bigdecimals options) (.enable DeserializationFeature/USE_BIG_DECIMAL_FOR_FLOATS)
-                   (:strip-nils options) (.setSerializationInclusion JsonInclude$Include/NON_EMPTY)
+                   (:strip-nils options) (.setSerializationInclusion JsonInclude$Include/NON_NULL)
                    (:do-not-fail-on-empty-beans options) (.disable SerializationFeature/FAIL_ON_EMPTY_BEANS)
                    (:escape-non-ascii options) (doto (-> .getFactory (.enable JsonGenerator$Feature/ESCAPE_NON_ASCII)))))]
      (doseq [module (:modules options)]

--- a/test/jsonista/core_test.clj
+++ b/test/jsonista/core_test.clj
@@ -55,8 +55,8 @@
     (testing ":pretty"
       (is (= "{\n  \"hello\" : \"world\"\n}" (j/write-value-as-string data (j/object-mapper {:pretty true})))))
     (testing ":strip-nils"
-      (let [data-with-nils {:hello "world" :goodbye nil}]
-        (is (= "{\"hello\":\"world\"}" (j/write-value-as-string data-with-nils (j/object-mapper {:strip-nils true}))))))
+      (let [data-with-nils {:hello "world" :goodbye nil :empty-string "" :empty-map {}}]
+        (is (= "{\"hello\":\"world\",\"empty-string\":\"\",\"empty-map\":{}}" (j/write-value-as-string data-with-nils (j/object-mapper {:strip-nils true}))))))
     (testing ":escape-non-ascii"
       (is (= "{\"imperial-money\":\"\\u00A3\"}" (j/write-value-as-string {:imperial-money "£"} (j/object-mapper {:escape-non-ascii true})))))
     (testing ":date-format"

--- a/test/jsonista/core_test.clj
+++ b/test/jsonista/core_test.clj
@@ -55,6 +55,9 @@
     (testing ":pretty"
       (is (= "{\n  \"hello\" : \"world\"\n}" (j/write-value-as-string data (j/object-mapper {:pretty true})))))
     (testing ":strip-nils"
+      (let [data-with-nils {:hello "world" :goodbye nil}]
+        (is (= "{\"hello\":\"world\"}" (j/write-value-as-string data-with-nils (j/object-mapper {:strip-nils true}))))))
+    (testing ":strip-nils doesn't strip other empties"
       (let [data-with-nils {:hello "world" :goodbye nil :empty-string "" :empty-map {}}]
         (is (= "{\"hello\":\"world\",\"empty-string\":\"\",\"empty-map\":{}}" (j/write-value-as-string data-with-nils (j/object-mapper {:strip-nils true}))))))
     (testing ":escape-non-ascii"


### PR DESCRIPTION
I'm not sure if this is considered a bug, but it has recently caught us by surprise. If it's not a bug then`:strip-nils` option seems misnamed as it is more of a `strip-empties`, removing empty strings, maps, vectors, etc.

This change obviously potentially breaks backwards compatibility so I'm not sure if you'd want to include it as is (and whether you'd still want to support some strip-empties variant), but it does currently feel like a bug as the behaviour doesn't match what's implied by the name of the option, it's [description](https://github.com/metosin/jsonista/blob/16a826a14c6ed417e8db90ec8ebc3d1440b26131/src/clj/jsonista/core.clj#L128) or the intent of the [original PR](https://github.com/metosin/jsonista/pull/67).

Thanks for your time and for all the wonderful metosin libraries 😄 