### PR TITLE
Update dependencies, fixes vulnerability in jackson-core 2.18.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,21 +17,21 @@
   :codox {:source-uri "http://github.com/metosin/jsonista/blob/master/{filepath}#L{line}"
           :output-path "doc"
           :metadata {:doc/format :markdown}}
-  :dependencies [[com.fasterxml.jackson.core/jackson-core "2.18.2"]
-                 [com.fasterxml.jackson.core/jackson-databind "2.18.2"]
-                 [com.fasterxml.jackson.datatype/jackson-datatype-jsr310 "2.18.2"]]
-  :profiles {:provided {:dependencies [[org.clojure/clojure "1.12.0"]]}
-             :dev {:dependencies [[org.clojure/clojure "1.12.0"]
+  :dependencies [[com.fasterxml.jackson.core/jackson-core "2.21.1"]
+                 [com.fasterxml.jackson.core/jackson-databind "2.21.1"]
+                 [com.fasterxml.jackson.datatype/jackson-datatype-jsr310 "2.21.1"]]
+  :profiles {:provided {:dependencies [[org.clojure/clojure "1.12.4"]]}
+             :dev {:dependencies [[org.clojure/clojure "1.12.4"]
                                   [jmh-clojure/jmh-clojure "0.4.1"]
-                                  [com.fasterxml.jackson.datatype/jackson-datatype-joda "2.18.2"]
-                                  [cheshire "5.13.0"]
-                                  [com.taoensso/nippy "3.4.2"]
-                                  [org.clojure/data.json "2.5.1"]
-                                  [com.cognitect/transit-clj "1.0.333"]
-                                  [org.msgpack/msgpack-core "0.9.8"]
-                                  [org.msgpack/jackson-dataformat-msgpack "0.9.8"
+                                  [com.fasterxml.jackson.datatype/jackson-datatype-joda "2.21.1"]
+                                  [cheshire "6.1.0"]
+                                  [com.taoensso/nippy "3.6.0"]
+                                  [org.clojure/data.json "2.5.2"]
+                                  [com.cognitect/transit-clj "1.1.347"]
+                                  [org.msgpack/msgpack-core "0.9.11"]
+                                  [org.msgpack/jackson-dataformat-msgpack "0.9.11"
                                    :exclusions [com.fasterxml.jackson.core/jackson-databind]]
-                                  [com.clojure-goes-fast/clj-async-profiler "1.5.1"]
+                                  [com.clojure-goes-fast/clj-async-profiler "1.7.0"]
                                   [criterium "0.4.6"]]
                    :global-vars {*warn-on-reflection* true}}
              :1.11 {:dependencies [[org.clojure/clojure "1.11.3"]]}


### PR DESCRIPTION
Fixes https://github.com/metosin/jsonista/issues/90.

`lein do clean, all test, all check` passes.
Also ran the perf tests before/after, no dramatic differences.