### PR TITLE
feat: speed up PersistentHashMapDeserializer

### DIFF
--- a/src/java/jsonista/jackson/PersistentHashMapDeserializer.java
+++ b/src/java/jsonista/jackson/PersistentHashMapDeserializer.java
@@ -44,33 +44,32 @@ public class PersistentHashMapDeserializer extends StdDeserializer<Map<String, O
   @Override
   @SuppressWarnings("unchecked")
   public Map<String, Object> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+    // Phase 1: collect up to 8 entries for a PersistentArrayMap
     Object[] entries = new Object[16];
     int size = 0;
+    while (size < 8) {
+      if (p.nextToken() == JsonToken.END_OBJECT) {
+        return (Map<String, Object>) PersistentArrayMap.createAsIfByAssoc(Arrays.copyOf(entries, size * 2));
+      }
+      Object key = _keyDeserializer.deserializeKey(p.getCurrentName(), ctxt);
+      p.nextToken();
+      Object value = _valueDeserializer.deserialize(p, ctxt);
+      entries[size * 2] = key;
+      entries[size * 2 + 1] = value;
+      size++;
+    }
+
+    // Phase 2: overflow into a PersistentHashMap
+    ITransientMap t = PersistentHashMap.EMPTY.asTransient();
+    for (int i = 0; i < 16; i += 2) {
+      t = t.assoc(entries[i], entries[i + 1]);
+    }
     while (p.nextToken() != JsonToken.END_OBJECT) {
       Object key = _keyDeserializer.deserializeKey(p.getCurrentName(), ctxt);
       p.nextToken();
       Object value = _valueDeserializer.deserialize(p, ctxt);
-      if (size < 8) {
-        int i = size << 1;
-        entries[i] = key;
-        entries[i + 1] = value;
-        size++;
-      } else {
-        ITransientMap t = PersistentHashMap.EMPTY.asTransient();
-        for (int i = 0; i < size << 1; i += 2) {
-          t = t.assoc(entries[i], entries[i + 1]);
-        }
-        t = t.assoc(key, value);
-        while (p.nextToken() != JsonToken.END_OBJECT) {
-          Object nextKey = _keyDeserializer.deserializeKey(p.getCurrentName(), ctxt);
-          p.nextToken();
-          Object nextValue = _valueDeserializer.deserialize(p, ctxt);
-          t = t.assoc(nextKey, nextValue);
-        }
-        return (Map<String, Object>) t.persistent();
-      }
+      t = t.assoc(key, value);
     }
-
-    return (Map<String, Object>) PersistentArrayMap.createAsIfByAssoc(Arrays.copyOf(entries, size << 1));
+    return (Map<String, Object>) t.persistent();
   }
 }

--- a/src/java/jsonista/jackson/PersistentHashMapDeserializer.java
+++ b/src/java/jsonista/jackson/PersistentHashMapDeserializer.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Map;
 
 public class PersistentHashMapDeserializer extends StdDeserializer<Map<String, Object>> implements ContextualDeserializer {
@@ -43,15 +44,33 @@ public class PersistentHashMapDeserializer extends StdDeserializer<Map<String, O
   @Override
   @SuppressWarnings("unchecked")
   public Map<String, Object> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
-    ITransientMap t = PersistentHashMap.EMPTY.asTransient();
+    Object[] entries = new Object[16];
+    int size = 0;
     while (p.nextToken() != JsonToken.END_OBJECT) {
       Object key = _keyDeserializer.deserializeKey(p.getCurrentName(), ctxt);
       p.nextToken();
       Object value = _valueDeserializer.deserialize(p, ctxt);
-      t = t.assoc(key, value);
+      if (size < 8) {
+        int i = size << 1;
+        entries[i] = key;
+        entries[i + 1] = value;
+        size++;
+      } else {
+        ITransientMap t = PersistentHashMap.EMPTY.asTransient();
+        for (int i = 0; i < size << 1; i += 2) {
+          t = t.assoc(entries[i], entries[i + 1]);
+        }
+        t = t.assoc(key, value);
+        while (p.nextToken() != JsonToken.END_OBJECT) {
+          Object nextKey = _keyDeserializer.deserializeKey(p.getCurrentName(), ctxt);
+          p.nextToken();
+          Object nextValue = _valueDeserializer.deserialize(p, ctxt);
+          t = t.assoc(nextKey, nextValue);
+        }
+        return (Map<String, Object>) t.persistent();
+      }
     }
 
-    // t.persistent() returns a PersistentHashMap, which is a Map.
-    return (Map<String, Object>) t.persistent();
+    return (Map<String, Object>) PersistentArrayMap.createAsIfByAssoc(Arrays.copyOf(entries, size << 1));
   }
 }


### PR DESCRIPTION
A speculative benchmark optimization for the decode code path. I found this by running [pi-autoresearch](https://github.com/davebcn87/pi-autoresearch) with `gpt-5.4-medium` against the benchmark. The idea is similar in spirit to #17 (which didn't work) but the PersistentArrayMap construction is inlined

This is what I got for the `jsonista.jmh/decode-jsonista` benchmark on my laptop, `master` vs this branch:

| Size | Main | PR | Change |
| --- | ---: | ---: | ---: |
| 10b | 9,285,018.601 ops/s | 11,050,553.982 ops/s | +19.01% |
| 100b | 2,026,489.218 ops/s | 2,367,886.089 ops/s | +16.85% |
| 1k | 363,486.397 ops/s | 418,933.267 ops/s | +15.25% |
| 10k | 32,911.114 ops/s | 37,307.349 ops/s | +13.36% |
| 100k | 3,342.422 ops/s | 3,644.178 ops/s | +9.03% |

I'm not sure what to make of this - is this a good idea, or is it possibly overfitting to the benchmark dataset?

<details>
<summary>Version info</summary>

```
% java --version
openjdk 25.0.2 2026-01-20
OpenJDK Runtime Environment Homebrew (build 25.0.2)
OpenJDK 64-Bit Server VM Homebrew (build 25.0.2, mixed mode, sharing)
% clj --version
Clojure CLI version 1.12.4.1618
```

</details>